### PR TITLE
Configuration through __construct()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- new constructor in `Youthweb\UrlLinker\UrlLinker` for configuration
+
+### Deprecated
+- Deprecated `Youthweb\UrlLinker\UrlLinker::setAllowFtpAddresses()`
+- Deprecated `Youthweb\UrlLinker\UrlLinker::getAllowFtpAddresses()`
+- Deprecated `Youthweb\UrlLinker\UrlLinker::setAllowUpperCaseUrlSchemes()`
+- Deprecated `Youthweb\UrlLinker\UrlLinker::getAllowUpperCaseUrlSchemes()`
+- Deprecated `Youthweb\UrlLinker\UrlLinker::setHtmlLinkCreator()`
+- Deprecated `Youthweb\UrlLinker\UrlLinker::getHtmlLinkCreator()`
+- Deprecated `Youthweb\UrlLinker\UrlLinker::setEmailLinkCreator()`
+- Deprecated `Youthweb\UrlLinker\UrlLinker::getEmailLinkCreator()`
+- Deprecated `Youthweb\UrlLinker\UrlLinker::setValidTlds()`
+- Deprecated `Youthweb\UrlLinker\UrlLinker::getValidTlds()`
+
 ## [1.0] - 2016-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,29 +27,36 @@ $urlLinker->linkUrlsAndEscapeHtml($text);
 $urlLinker->linkUrlsInTrustedHtml($html);
 ```
 
-You can configure different options for parsing URLs by passing them to `UrlLinker`:
+You can optional configure different options for parsing URLs by passing them to `UrlLinker::__construct()`:
 
 ```php
-// Ftp addresses like "ftp://example.com" will be allowed:
-$urlLinker->setAllowFtpAddresses(true);
+$config = [
+    // Ftp addresses like "ftp://example.com" will be allowed, default false
+    'allowFtpAddresses' => true,
 
-// Uppercase URL schemes like "HTTP://exmaple.com" will be allowed:
-$urlLinker->setAllowUpperCaseUrlSchemes(true);
+    // Uppercase URL schemes like "HTTP://exmaple.com" will be allowed:
+    'setAllowUpperCaseUrlSchemes' => true,
 
-// Add a Closure to modify the way the urls will be linked:
-$urlLinker->setHtmlLinkCreator(function($url, $content)
-{
-    return '<a href="' . $url . '" target="_blank">' . $content . '</a>';
-});
+    // Add a Closure to modify the way the urls will be linked:
+    'htmlLinkCreator' => function($url, $content)
+    {
+        return '<a href="' . $url . '" target="_blank">' . $content . '</a>';
+    },
 
-// Add a Closure to modify the way the emails will be linked:
-$urlLinker->setEmailLinkCreator(function($email, $content)
-{
-    return '<a href="mailto:' . $email . '" class="email">' . $content . '</a>';
-});
+    // Add a Closure to modify the way the emails will be linked:
+    'emailLinkCreator' => function($email, $content)
+    {
+        return '<a href="mailto:' . $email . '" class="email">' . $content . '</a>';
+    },
 
-// You can also disable the links for email with a closure:
-$urlLinker->setEmailLinkCreator(function($email, $content) { return $email; });
+    // You can also disable the links for email with a closure:
+    'emailLinkCreator' => function($email, $content) { return $email; },
+
+    // You can customize the recognizable Top Level Domains:
+    'validTlds' => ['.local' => true],
+];
+
+$urlLinker = new Youthweb\UrlLinker\UrlLinker($config);
 ```
 
 ## Recognized addresses

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $config = [
     'allowFtpAddresses' => true,
 
     // Uppercase URL schemes like "HTTP://exmaple.com" will be allowed:
-    'setAllowUpperCaseUrlSchemes' => true,
+    'allowUpperCaseUrlSchemes' => true,
 
     // Add a Closure to modify the way the urls will be linked:
     'htmlLinkCreator' => function($url, $content)
@@ -53,7 +53,7 @@ $config = [
     'emailLinkCreator' => function($email, $content) { return $email; },
 
     // You can customize the recognizable Top Level Domains:
-    'validTlds' => ['.local' => true],
+    'validTlds' => ['.localhost' => true],
 ];
 
 $urlLinker = new Youthweb\UrlLinker\UrlLinker($config);
@@ -65,9 +65,9 @@ $urlLinker = new Youthweb\UrlLinker\UrlLinker($config);
   - Recognized URL schemes: "http" and "https"
     - The `http://` prefix is optional.
     - Support for additional schemes, e.g. "ftp", can easily be added by
-      setting `setAllowFtpAddresses(true)`.
+      setting `allowFtpAddresses` to `true`.
     - The scheme must be written in lower case. This requirement can be lifted
-      by setting `setAllowUpperCaseUrlSchemes(true)`.
+      by setting `allowUpperCaseUrlSchemes` to `true`.
   - Hosts may be specified using domain names or IPv4 addresses.
     - IPv6 addresses are not supported.
   - Port numbers are allowed.
@@ -82,9 +82,9 @@ $urlLinker = new Youthweb\UrlLinker\UrlLinker($config);
     - Internationalized *top-level* domain names must be written in Punycode in
       order to be recognized.
     - If you want to support only some specific TLD you can set them with
-      `setValidTlds(['.com' => true, '.net' => true])`
+      `validTlds` e.g. `['.com' => true, '.net' => true]`.
     - If you need to support unqualified domain names, such as `localhost`,
-      you can also set them with `setValidTlds(['.localhost' => true])`
+      you can also set them with `['.localhost' => true]` in `validTlds`.
 - Email addresses
   - Supports the full range of commonly used address formats, including "plus
     addresses" (as popularized by Gmail).
@@ -93,7 +93,7 @@ $urlLinker = new Youthweb\UrlLinker\UrlLinker($config);
   - Simplistic spam protection: The at-sign is converted to a HTML entity,
     foiling naive email address harvesters.
   - If you don't want to link emails you can set closure that simply returns the
-    raw email with `setEmailLinkCreator(function($email, $content) { return $email; })`
+    raw email with a closure `function($email, $content) { return $email; }` in `emailLinkCreator`.
 - Addresses are recognized correctly in normal sentence contexts. For instance,
   in "Visit stackoverflow.com.", the final period is not part of the URL.
 - User input is properly sanitized to prevent [cross-site scripting](http://en.wikipedia.org/wiki/Cross-site_scripting) (XSS),

--- a/src/UrlLinker.php
+++ b/src/UrlLinker.php
@@ -7,12 +7,12 @@ final class UrlLinker implements UrlLinkerInterface
 	/**
 	 * @var bool
 	 */
-	private $allowFtpAddresses = false;
+	private $allowFtpAddresses;
 
 	/**
 	 * @var bool
 	 */
-	private $allowUpperCaseUrlSchemes = false;
+	private $allowUpperCaseUrlSchemes;
 
 	/**
 	 * @var Closure
@@ -28,6 +28,42 @@ final class UrlLinker implements UrlLinkerInterface
 	 * @var array
 	 */
 	private $validTlds;
+
+	/**
+	 * Set the configuration
+	 *
+	 * @since v1.1.0
+	 * @param array $options Configuation array
+	 * @return self
+	 */
+	public function __construct(array $options = [])
+	{
+		$default_options = [
+			'allowFtpAddresses' => false,
+			'allowUpperCaseUrlSchemes' => false,
+			'htmlLinkCreator' => function($url, $content)
+			{
+				return $this->createHtmlLink($url, $content);
+			},
+			'emailLinkCreator' => function($url, $content)
+			{
+				return $this->createEmailLink($url, $content);
+			},
+			'validTlds' => DomainStorage::getValidTlds(),
+		];
+
+		foreach ($default_options as $key => $value)
+		{
+			if ( array_key_exists($key, $options) )
+			{
+				$this->$key = $options[$key];
+			}
+			else
+			{
+				$this->$key = $value;
+			}
+		}
+	}
 
 	/**
 	 * @param bool $allowFtpAddresses
@@ -83,14 +119,6 @@ final class UrlLinker implements UrlLinkerInterface
 	 */
 	public function getHtmlLinkCreator()
 	{
-		if ( $this->htmlLinkCreator === null )
-		{
-			$this->htmlLinkCreator = function($url, $content)
-			{
-				return $this->createHtmlLink($url, $content);
-			};
-		}
-
 		return $this->htmlLinkCreator;
 	}
 
@@ -110,14 +138,6 @@ final class UrlLinker implements UrlLinkerInterface
 	 */
 	public function getEmailLinkCreator()
 	{
-		if ( $this->emailLinkCreator === null )
-		{
-			$this->emailLinkCreator = function($url, $content)
-			{
-				return $this->createEmailLink($url, $content);
-			};
-		}
-
 		return $this->emailLinkCreator;
 	}
 
@@ -137,11 +157,6 @@ final class UrlLinker implements UrlLinkerInterface
 	 */
 	public function getValidTlds()
 	{
-		if ( $this->validTlds === null )
-		{
-			$this->validTlds = DomainStorage::getValidTlds();
-		}
-
 		return $this->validTlds;
 	}
 

--- a/src/UrlLinker.php
+++ b/src/UrlLinker.php
@@ -85,97 +85,127 @@ final class UrlLinker implements UrlLinkerInterface
 	}
 
 	/**
+	 * @deprecated since version 1.1, to be set to private in 2.0. Use config setting through __construct() instead
 	 * @param bool $allowFtpAddresses
 	 * @return self
 	 */
 	public function setAllowFtpAddresses($allowFtpAddresses)
 	{
+		@trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0. Use config setting through __construct() instead', E_USER_DEPRECATED);
+
 		$this->allowFtpAddresses = (bool) $allowFtpAddresses;
 
 		return $this;
 	}
 
 	/**
+	 * @deprecated since version 1.1, to be set to private in 2.0.
 	 * @return bool
 	 */
 	public function getAllowFtpAddresses()
 	{
+		@trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.', E_USER_DEPRECATED);
+
 		return $this->allowFtpAddresses;
 	}
 
 	/**
+	 * @deprecated since version 1.1, to be set to private in 2.0. Use config setting through __construct() instead
 	 * @param bool $allowUpperCaseUrlSchemes
 	 * @return self
 	 */
 	public function setAllowUpperCaseUrlSchemes($allowUpperCaseUrlSchemes)
 	{
+		@trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0. Use config setting through __construct() instead', E_USER_DEPRECATED);
+
 		$this->allowUpperCaseUrlSchemes = (bool) $allowUpperCaseUrlSchemes;
 
 		return $this;
 	}
 
 	/**
+	 * @deprecated since version 1.1, to be set to private in 2.0.
 	 * @return bool
 	 */
 	public function getAllowUpperCaseUrlSchemes()
 	{
+		@trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.', E_USER_DEPRECATED);
+
 		return $this->allowUpperCaseUrlSchemes;
 	}
 
 	/**
+	 * @deprecated since version 1.1, to be set to private in 2.0. Use config setting through __construct() instead
 	 * @param Closure $creator
 	 * @return self
 	 */
 	public function setHtmlLinkCreator(\Closure $creator)
 	{
+		@trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0. Use config setting through __construct() instead', E_USER_DEPRECATED);
+
 		$this->htmlLinkCreator = $creator;
 
 		return $this;
 	}
 
 	/**
+	 * @deprecated since version 1.1, to be set to private in 2.0.
 	 * @return Closure
 	 */
 	public function getHtmlLinkCreator()
 	{
+		@trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.', E_USER_DEPRECATED);
+
 		return $this->htmlLinkCreator;
 	}
 
 	/**
+	 * @deprecated since version 1.1, to be set to private in 2.0. Use config setting through __construct() instead
 	 * @param Closure $creator
 	 * @return self
 	 */
 	public function setEmailLinkCreator(\Closure $creator)
 	{
+		@trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0. Use config setting through __construct() instead', E_USER_DEPRECATED);
+
 		$this->emailLinkCreator = $creator;
 
 		return $this;
 	}
 
 	/**
+	 * @deprecated since version 1.1, to be set to private in 2.0.
 	 * @return Closure
 	 */
 	public function getEmailLinkCreator()
 	{
+		@trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.', E_USER_DEPRECATED);
+
 		return $this->emailLinkCreator;
 	}
 
 	/**
+	 * @deprecated since version 1.1, to be set to private in 2.0. Use config setting through __construct() instead
 	 * @param array $validTlds
 	 * @return self
 	 */
 	public function setValidTlds(array $validTlds)
 	{
+		@trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0. Use config setting through __construct() instead', E_USER_DEPRECATED);
+
 		$this->validTlds = $validTlds;
 
 		return $this;
 	}
 
 	/**
+	 * @deprecated since version 1.1, to be set to private in 2.0.
 	 * @return bool
 	 */
 	public function getValidTlds()
 	{
+		@trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.', E_USER_DEPRECATED);
+
 		return $this->validTlds;
 	}
 

--- a/src/UrlLinker.php
+++ b/src/UrlLinker.php
@@ -56,11 +56,30 @@ final class UrlLinker implements UrlLinkerInterface
 		{
 			if ( array_key_exists($key, $options) )
 			{
-				$this->$key = $options[$key];
+				$value = $options[$key];
 			}
-			else
+
+			switch ($key)
 			{
-				$this->$key = $value;
+				case 'allowFtpAddresses':
+					$this->setAllowFtpAddresses($value);
+					break;
+
+				case 'allowUpperCaseUrlSchemes':
+					$this->setAllowUpperCaseUrlSchemes($value);
+					break;
+
+				case 'htmlLinkCreator':
+					$this->setHtmlLinkCreator($value);
+					break;
+
+				case 'emailLinkCreator':
+					$this->setEmailLinkCreator($value);
+					break;
+
+				case 'validTlds':
+					$this->setValidTlds($value);
+					break;
 			}
 		}
 	}

--- a/tests/integration/UrlLinkerEscapingHtmlTest.php
+++ b/tests/integration/UrlLinkerEscapingHtmlTest.php
@@ -23,7 +23,9 @@ class UrlLinkerEscapingHtmlTest extends UrlLinkerTestCase
 	 */
 	public function testFtpUrlsGetLinkedInText($text, $expectedLinked, $message = null)
 	{
-		$this->urlLinker->setAllowFtpAddresses(true);
+		$this->urlLinker = new UrlLinker([
+			'allowFtpAddresses' => true,
+		]);
 
 		$this->testUrlsGetLinkedInText($text, $expectedLinked, $message);
 	}
@@ -35,7 +37,9 @@ class UrlLinkerEscapingHtmlTest extends UrlLinkerTestCase
 	 */
 	public function testUppercaseUrlsGetLinkedInText($text, $expectedLinked, $message = null)
 	{
-		$this->urlLinker->setAllowUpperCaseUrlSchemes(true);
+		$this->urlLinker = new UrlLinker([
+			'allowUpperCaseUrlSchemes' => true,
+		]);
 
 		$this->testUrlsGetLinkedInText($text, $expectedLinked, $message);
 	}
@@ -135,7 +139,9 @@ EOD;
 	 */
 	public function testHtmlInText($text, $expectedLinked, $message = null)
 	{
-		$this->urlLinker->setAllowUpperCaseUrlSchemes(true);
+		$this->urlLinker = new UrlLinker([
+			'allowUpperCaseUrlSchemes' => true,
+		]);
 
 		$this->testUrlsGetLinkedInText($text, $expectedLinked);
 	}

--- a/tests/integration/UrlLinkerInTrustedHtmlTest.php
+++ b/tests/integration/UrlLinkerInTrustedHtmlTest.php
@@ -23,7 +23,9 @@ class UrlLinkerInTrustedHtmlTest extends UrlLinkerTestCase
 	 */
 	public function testFtpUrlsGetLinkedInText($text, $expectedLinked, $message = null)
 	{
-		$this->urlLinker->setAllowFtpAddresses(true);
+		$this->urlLinker = new UrlLinker([
+			'allowFtpAddresses' => true,
+		]);
 
 		$this->testUrlsGetLinkedInText($text, $expectedLinked, $message);
 	}
@@ -35,7 +37,9 @@ class UrlLinkerInTrustedHtmlTest extends UrlLinkerTestCase
 	 */
 	public function testUppercaseUrlsGetLinkedInText($text, $expectedLinked, $message = null)
 	{
-		$this->urlLinker->setAllowUpperCaseUrlSchemes(true);
+		$this->urlLinker = new UrlLinker([
+			'allowUpperCaseUrlSchemes' => true,
+		]);
 
 		$this->testUrlsGetLinkedInText($text, $expectedLinked, $message);
 	}
@@ -107,7 +111,9 @@ EOD;
 	 */
 	public function testHtmlInText($text, $expectedLinked, $message = null)
 	{
-		$this->urlLinker->setAllowUpperCaseUrlSchemes(true);
+		$this->urlLinker = new UrlLinker([
+			'allowUpperCaseUrlSchemes' => true,
+		]);
 
 		$this->testUrlsGetLinkedInText($text, $expectedLinked);
 	}

--- a/tests/integration/UrlLinkerTest.php
+++ b/tests/integration/UrlLinkerTest.php
@@ -6,6 +6,9 @@ use Youthweb\UrlLinker\UrlLinker;
 
 class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 {
+	/**
+	 * @deprecated since version 1.1, to be removed in 2.0.
+	 */
 	public function testGetValidTlds()
 	{
 		$urlLinker = new UrlLinker();
@@ -35,15 +38,15 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testCustomHtmlLinkCreator()
 	{
-		$urlLinker = new UrlLinker();
-
 		// Simple htmlLinkCreator
 		$creator = function($url, $content)
 		{
 			return '<a href="' . $url . '" target="_blank">' . $content . '</a>';
 		};
 
-		$urlLinker->setHtmlLinkCreator($creator);
+		$urlLinker = new UrlLinker([
+			'htmlLinkCreator' => $creator,
+		]);
 
 		$text = 'example.com';
 		$expected = '<a href="http://example.com" target="_blank">example.com</a>';
@@ -69,15 +72,15 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testCustomEmailLinkCreator()
 	{
-		$urlLinker = new UrlLinker();
-
 		// Simple EmailLinkCreator
 		$creator = function($email, $content)
 		{
 			return '<a href="' . $email . '" class="email">' . $content . '</a>';
 		};
 
-		$urlLinker->setEmailLinkCreator($creator);
+		$urlLinker = new UrlLinker([
+			'emailLinkCreator' => $creator,
+		]);
 
 		$text = 'mail@example.com';
 		$expected = '<a href="mail@example.com" class="email">mail@example.com</a>';
@@ -90,15 +93,15 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testDisableEmailLinkCreator()
 	{
-		$urlLinker = new UrlLinker();
-
 		// This EmailLinkCreator returns simply the email
 		$creator = function($email, $content)
 		{
 			return $email;
 		};
 
-		$urlLinker->setEmailLinkCreator($creator);
+		$urlLinker = new UrlLinker([
+			'emailLinkCreator' => $creator,
+		]);
 
 		$text = 'mail@example.com';
 		$expected = 'mail@example.com';

--- a/tests/unit/UrlLinkerTest.php
+++ b/tests/unit/UrlLinkerTest.php
@@ -12,10 +12,15 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 
 		$this->assertInstanceOf('Youthweb\UrlLinker\UrlLinkerInterface', $urlLinker);
 
+		// @deprecated since version 1.1, to be removed in 2.0.
 		$this->assertFalse($urlLinker->getAllowFtpAddresses());
+		// @deprecated since version 1.1, to be removed in 2.0.
 		$this->assertFalse($urlLinker->getAllowUpperCaseUrlSchemes());
 	}
 
+	/**
+	 * @deprecated since version 1.1, to be removed in 2.0.
+	 */
 	public function testAllowFtpAddressesConfig()
 	{
 		$urlLinker = new UrlLinker();
@@ -27,6 +32,9 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 		$this->assertTrue($urlLinker->getAllowFtpAddresses());
 	}
 
+	/**
+	 * @deprecated since version 1.1, to be removed in 2.0.
+	 */
 	public function testAllowUpperCaseUrlSchemesConfig()
 	{
 		$urlLinker = new UrlLinker();
@@ -38,6 +46,9 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 		$this->assertTrue($urlLinker->getAllowUpperCaseUrlSchemes());
 	}
 
+	/**
+	 * @deprecated since version 1.1, to be removed in 2.0.
+	 */
 	public function testValidTldsConfig()
 	{
 		$urlLinker = new UrlLinker();
@@ -51,6 +62,8 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * Test that getHtmlLinkCreator() allways returns a closure
+	 *
+	 * @deprecated since version 1.1, to be removed in 2.0.
 	 */
 	public function testGetHtmlLinkCreator()
 	{
@@ -61,6 +74,8 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * Test that a closure can be set
+	 *
+	 * @deprecated since version 1.1, to be removed in 2.0.
 	 */
 	public function testSetHtmlLinkCreator()
 	{
@@ -80,6 +95,8 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * Test that getEmailLinkCreator() allways returns a closure
+	 *
+	 * @deprecated since version 1.1, to be removed in 2.0.
 	 */
 	public function testGetEmailLinkCreator()
 	{
@@ -90,6 +107,8 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * Test that a closure can be set
+	 *
+	 * @deprecated since version 1.1, to be removed in 2.0.
 	 */
 	public function testSetEmailLinkCreator()
 	{
@@ -107,6 +126,9 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 		$this->assertSame($creator, $urlLinker->getEmailLinkCreator());
 	}
 
+	/**
+	 * @deprecated since version 1.1, to be removed in 2.0.
+	 */
 	public function testAllowingFtpAddresses()
 	{
 		$urlLinker = new UrlLinker();
@@ -127,6 +149,9 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
 		$this->assertSame($expectedHtml, $urlLinker->linkUrlsInTrustedHtml($html));
 	}
 
+	/**
+	 * @deprecated since version 1.1, to be removed in 2.0.
+	 */
 	public function testAllowingUpperCaseSchemes()
 	{
 		$urlLinker = new UrlLinker();


### PR DESCRIPTION
This PR allows the configuration through `UrlLinker::__construct()`. The existing getter and setter will be deprecated, but remain for BC until version 2.0.