### PR TITLE
add static code analysis with PHPStan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         php: ['8.1', '8.2']
 
-    name: "Static code check with PHPStan on PHP ${{ matrix.php }}"
+    name: "PHPStan on PHP ${{ matrix.php }}"
     continue-on-error: ${{ matrix.php == '8.2' }}
 
     steps:
@@ -54,7 +54,7 @@ jobs:
       matrix:
         php: ['7.4', '8.0', '8.1', '8.2']
 
-    name: "Run PHPUnit with PHP ${{ matrix.php }}"
+    name: "PHPUnit on PHP ${{ matrix.php }}"
     continue-on-error: ${{ matrix.php == '8.2' }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,44 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ['7.4', '8.0', '8.1', '8.2']
-
-    name: "PHP: ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.php == '8.2' }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Install PHP with latest composer
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
-          coverage: none
-          tools: none
-
-      # Install dependencies and handle caching in one go.
-      # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: "Install Composer dependencies (PHP < 8.2)"
-        if: ${{ matrix.php < '8.2' }}
-        uses: "ramsey/composer-install@v2"
-
-      - name: "Install Composer dependencies (PHP 8.2)"
-        if: ${{ matrix.php >= '8.2' }}
-        uses: "ramsey/composer-install@v2"
-        with:
-          composer-options: --ignore-platform-reqs
-
-      - name: Run unit tests
-        run: vendor/bin/phpunit
-
   phpstan:
     runs-on: ubuntu-latest
 
@@ -83,3 +45,41 @@ jobs:
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyze
+
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.4', '8.0', '8.1', '8.2']
+
+    name: "Run PHPUnit with PHP ${{ matrix.php }}"
+    continue-on-error: ${{ matrix.php == '8.2' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP with latest composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
+          coverage: none
+          tools: none
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: "Install Composer dependencies (PHP < 8.2)"
+        if: ${{ matrix.php < '8.2' }}
+        uses: "ramsey/composer-install@v2"
+
+      - name: "Install Composer dependencies (PHP 8.2)"
+        if: ${{ matrix.php >= '8.2' }}
+        uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: --ignore-platform-reqs
+
+      - name: Run unit tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,41 @@ jobs:
 
       - name: Run unit tests
         run: vendor/bin/phpunit
+
+  phpstan:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2']
+
+    name: "Static code check with PHPStan on PHP ${{ matrix.php }}"
+    continue-on-error: ${{ matrix.php == '8.2' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP with latest composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
+          coverage: none
+          tools: none
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: "Install Composer dependencies (PHP < 8.2)"
+        if: ${{ matrix.php < '8.2' }}
+        uses: "ramsey/composer-install@v2"
+
+      - name: "Install Composer dependencies (PHP 8.2)"
+        if: ${{ matrix.php >= '8.2' }}
+        uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: --ignore-platform-reqs
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyze

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Providing the config option `emailLinkCreator` to `Youthweb\UrlLinker\UrlLinker::__construct()` as `callable` is deprecated, provide as `Closure` instead.
 - Providing the config option `allowFtpAddresses` to `Youthweb\UrlLinker\UrlLinker::__construct()` not as `boolean` is deprecated, provide as `boolean` instead.
 - Providing the config option `allowUpperCaseUrlSchemes` to `Youthweb\UrlLinker\UrlLinker::__construct()` not as `boolean` is deprecated, provide as `boolean` instead.
+- Implementing `Youthweb\UrlLinker\UrlLinkerInterface::linkUrlsAndEscapeHtml()` without return type `string` is deprecated, add `string` as return type in your implementation instead.
+- Implementing `Youthweb\UrlLinker\UrlLinkerInterface::linkUrlsInTrustedHtml()` without return type `string` is deprecated, add `string` as return type in your implementation instead.
 
 ## [1.4.0](https://github.com/youthweb/urllinker/compare/1.3.0...1.4.0) - 2021-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Providing the config option `htmlLinkCreator` to `Youthweb\UrlLinker\UrlLinker::__construct()` as `callable` is deprecated, provide as `Closure` instead.
 - Providing the config option `emailLinkCreator` to `Youthweb\UrlLinker\UrlLinker::__construct()` as `callable` is deprecated, provide as `Closure` instead.
+- Providing the config option `allowFtpAddresses` to `Youthweb\UrlLinker\UrlLinker::__construct()` not as `boolean` is deprecated, provide as `boolean` instead.
+- Providing the config option `allowUpperCaseUrlSchemes` to `Youthweb\UrlLinker\UrlLinker::__construct()` not as `boolean` is deprecated, provide as `boolean` instead.
 
 ## [1.4.0](https://github.com/youthweb/urllinker/compare/1.3.0...1.4.0) - 2021-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add type declarations for attributes, parameters and return values in nearly all classes
 - Add tests for PHP 8.1 and 8.2
 
 ### Changed
 
 - Update the IANA TLD list
 - Move CI tests from Travis-CI to Github Actions
+
+### Deprecated
+
+- Providing the config option `htmlLinkCreator` to `Youthweb\UrlLinker\UrlLinker::__construct()` as `callable` is deprecated, provide as `Closure` instead.
+- Providing the config option `emailLinkCreator` to `Youthweb\UrlLinker\UrlLinker::__construct()` as `callable` is deprecated, provide as `Closure` instead.
 
 ## [1.4.0](https://github.com/youthweb/urllinker/compare/1.3.0...1.4.0) - 2021-03-05
 
@@ -41,13 +47,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.2.0](https://github.com/youthweb/urllinker/compare/1.1.0...1.2.0) - 2017-08-24
 
-### Added
-
-- config `htmlLinkCreator` in `__construct()` can be a callable
-- config `emailLinkCreator` in `__construct()` can be a callable
-
 ### Changed
 
+- The provided config option `htmlLinkCreator` to `Youthweb\UrlLinker\UrlLinker::__construct()` can be a `callable`.
+- The provided config option `emailLinkCreator` to `Youthweb\UrlLinker\UrlLinker::__construct()` can be a `callable`.
 - Updated the IANA TLD list with ~50 more domains
 - The test files following PSR-4
 

--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ $config = [
     'allowUpperCaseUrlSchemes' => true,
 
     // Add a Closure to modify the way the urls will be linked:
-    'htmlLinkCreator' => function($url, $content)
+    'htmlLinkCreator' => function(string $url, string $content): string
     {
         return '<a href="' . $url . '" target="_blank">' . $content . '</a>';
     },
 
     // Add a Closure to modify the way the emails will be linked:
-    'emailLinkCreator' => function($email, $content)
+    'emailLinkCreator' => function(string $email, string $content): string
     {
         return '<a href="mailto:' . $email . '" class="email">' . $content . '</a>';
     },
 
     // You can also disable the links for email with a closure:
-    'emailLinkCreator' => function($email, $content) { return $email; },
+    'emailLinkCreator' => function(string $email, string $content): string { return $email; },
 
     // You can customize the recognizable Top Level Domains:
     'validTlds' => ['.localhost' => true],

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
 		"php": "^7.4 || ^8.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^9"
+		"phpunit/phpunit": "^9",
+		"phpstan/phpstan": "^1.9"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,9 @@
 		"psr-4": {
 			"Youthweb\\UrlLinker\\Tests\\": "tests"
 		}
+	},
+	"scripts": {
+		"check": "vendor/bin/phpstan analyze",
+		"test": "vendor/bin/phpunit"
 	}
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: src/UrlLinker.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
 	- phpstan-baseline.neon
 
 parameters:
-	level: 7
+	level: 8
 	paths:
 		- src
 		- tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+includes:
+	- phpstan-baseline.neon
+
+parameters:
+	level: 5
+	paths:
+		- src
+		- tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
 	- phpstan-baseline.neon
 
 parameters:
-	level: 5
+	level: 6
 	paths:
 		- src
 		- tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
 	- phpstan-baseline.neon
 
 parameters:
-	level: 6
+	level: 7
 	paths:
 		- src
 		- tests

--- a/src/DomainStorage.php
+++ b/src/DomainStorage.php
@@ -1522,7 +1522,7 @@ ZW';
     /**
      * Associative array mapping valid TLDs to the value true.
      *
-     * @var string
+     * @var array<string,bool>
      */
     private static $validTlds;
 

--- a/src/DomainStorage.php
+++ b/src/DomainStorage.php
@@ -1527,9 +1527,9 @@ ZW';
     private static $validTlds;
 
     /**
-     * @return array
+     * @return array<string,bool>
      */
-    public static function getValidTlds()
+    public static function getValidTlds(): array
     {
         if (! static::$validTlds) {
             $validTlds = explode("\n", static::$rawValidTlds);

--- a/src/UrlLinker.php
+++ b/src/UrlLinker.php
@@ -44,6 +44,9 @@ final class UrlLinker implements UrlLinkerInterface
      */
     private $emailLinkCreator;
 
+    /**
+     * @var array<string,bool>
+     */
     private array $validTlds;
 
     /**
@@ -51,9 +54,7 @@ final class UrlLinker implements UrlLinkerInterface
      *
      * @since v1.1.0
      *
-     * @param array $options Configuation array
-     *
-     * @return self
+     * @param array<string,mixed> $options Configuation array
      */
     public function __construct(array $options = [])
     {
@@ -226,11 +227,9 @@ final class UrlLinker implements UrlLinkerInterface
     /**
      * @deprecated since version 1.1, to be set to private in 2.0. Use config setting through __construct() instead
      *
-     * @param array $validTlds
-     *
-     * @return self
+     * @param array<string,bool> $validTlds
      */
-    public function setValidTlds(array $validTlds)
+    public function setValidTlds(array $validTlds): self
     {
         @trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0. Use config setting through __construct() instead', E_USER_DEPRECATED);
 
@@ -242,9 +241,9 @@ final class UrlLinker implements UrlLinkerInterface
     /**
      * @deprecated since version 1.1, to be set to private in 2.0.
      *
-     * @return array
+     * @return array<string,bool>
      */
-    public function getValidTlds()
+    public function getValidTlds(): array
     {
         @trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.', E_USER_DEPRECATED);
 
@@ -256,10 +255,8 @@ final class UrlLinker implements UrlLinkerInterface
      * turning URLs into links.
      *
      * @param string $text
-     *
-     * @return string
      */
-    public function linkUrlsAndEscapeHtml($text)
+    public function linkUrlsAndEscapeHtml(string $text): string
     {
         // We can abort if there is no . in $text
         if (strpos($text, '.') === false) {
@@ -341,10 +338,8 @@ final class UrlLinker implements UrlLinkerInterface
      * a malicious user can lead to system compromise through cross-site scripting.
      *
      * @param string $html
-     *
-     * @return string
      */
-    public function linkUrlsInTrustedHtml($html)
+    public function linkUrlsInTrustedHtml(string $html): string
     {
         $reMarkup = '{</?([a-z]+)([^"\'>]|"[^"]*"|\'[^\']*\')*>|&#?[a-zA-Z0-9]+;|$}';
 

--- a/src/UrlLinker.php
+++ b/src/UrlLinker.php
@@ -25,14 +25,14 @@ use InvalidArgumentException;
 final class UrlLinker implements UrlLinkerInterface
 {
     /**
-     * @var bool
+     * Ftp addresses like "ftp://example.com" will be allowed, default false
      */
-    private $allowFtpAddresses;
+    private bool $allowFtpAddresses = false;
 
     /**
-     * @var bool
+     * Uppercase URL schemes like "HTTP://exmaple.com" will be allowed:
      */
-    private $allowUpperCaseUrlSchemes;
+    private bool $allowUpperCaseUrlSchemes = false;
 
     /**
      * @var Closure
@@ -44,10 +44,7 @@ final class UrlLinker implements UrlLinkerInterface
      */
     private $emailLinkCreator;
 
-    /**
-     * @var array
-     */
-    private $validTlds;
+    private array $validTlds;
 
     /**
      * Set the configuration
@@ -245,7 +242,7 @@ final class UrlLinker implements UrlLinkerInterface
     /**
      * @deprecated since version 1.1, to be set to private in 2.0.
      *
-     * @return bool
+     * @return array
      */
     public function getValidTlds()
     {

--- a/src/UrlLinker.php
+++ b/src/UrlLinker.php
@@ -21,6 +21,7 @@ namespace Youthweb\UrlLinker;
 
 use Closure;
 use InvalidArgumentException;
+use UnexpectedValueException;
 
 final class UrlLinker implements UrlLinkerInterface
 {
@@ -113,7 +114,17 @@ final class UrlLinker implements UrlLinkerInterface
                         ), \E_USER_DEPRECATED);
 
                         $value = function(string $url, string $content) use ($value): string {
-                            return call_user_func($value, $url, $content);
+                            $return = call_user_func($value, $url, $content);
+
+                            if (! is_string($return)) {
+                                throw new UnexpectedValueException(sprintf(
+                                    'Return value of callable for "%s" must return value of type "string", "%s" given.',
+                                    'htmlLinkCreator',
+                                    function_exists('get_debug_type') ? get_debug_type($value): (is_object($value) ? get_class($value) : gettype($value))
+                                ));
+                            }
+
+                            return $return;
                         };
                     }
 
@@ -139,7 +150,17 @@ final class UrlLinker implements UrlLinkerInterface
                         ), \E_USER_DEPRECATED);
 
                         $value = function(string $url, string $content) use ($value): string {
-                            return call_user_func($value, $url, $content);
+                            $return = call_user_func($value, $url, $content);
+
+                            if (! is_string($return)) {
+                                throw new UnexpectedValueException(sprintf(
+                                    'Return value of callable for "%s" must return value of type "string", "%s" given.',
+                                    'htmlLinkCreator',
+                                    function_exists('get_debug_type') ? get_debug_type($value): (is_object($value) ? get_class($value) : gettype($value))
+                                ));
+                            }
+
+                            return $return;
                         };
                     }
 

--- a/src/UrlLinker.php
+++ b/src/UrlLinker.php
@@ -77,12 +77,30 @@ final class UrlLinker implements UrlLinkerInterface
 
             switch ($key) {
                 case 'allowFtpAddresses':
-                    $this->allowFtpAddresses = (bool) $value;
+                    if (! is_bool($value)) {
+                        @trigger_error(sprintf(
+                            'Providing option "%s" not as type "boolean" is deprecated since version 1.5 and will not casted in version 2.0, provide as "boolean" instead.',
+                            $key
+                        ), \E_USER_DEPRECATED);
+
+                        $value = (bool) $value;
+                    }
+
+                    $this->allowFtpAddresses = $value;
 
                     break;
 
                 case 'allowUpperCaseUrlSchemes':
-                    $this->allowUpperCaseUrlSchemes = (bool) $value;
+                    if (! is_bool($value)) {
+                        @trigger_error(sprintf(
+                            'Providing option "%s" not as type "boolean" is deprecated since version 1.5 and will not casted in version 2.0, provide as "boolean" instead.',
+                            $key
+                        ), \E_USER_DEPRECATED);
+
+                        $value = (bool) $value;
+                    }
+
+                    $this->allowUpperCaseUrlSchemes = $value;
 
                     break;
 

--- a/src/UrlLinker.php
+++ b/src/UrlLinker.php
@@ -35,14 +35,14 @@ final class UrlLinker implements UrlLinkerInterface
     private bool $allowUpperCaseUrlSchemes = false;
 
     /**
-     * @var Closure
+     * Closure to modify the way the urls will be linked
      */
-    private $htmlLinkCreator;
+    private Closure $htmlLinkCreator;
 
     /**
-     * @var Closure
+     * Closure to modify the way the emails will be linked
      */
-    private $emailLinkCreator;
+    private Closure $emailLinkCreator;
 
     /**
      * @var array<string,bool>
@@ -87,8 +87,25 @@ final class UrlLinker implements UrlLinkerInterface
                     break;
 
                 case 'htmlLinkCreator':
-                    if (! is_callable($value)) {
-                        throw new InvalidArgumentException('The value of the htmlLinkCreator option must be callable.');
+                    if (is_callable($value) and (! is_object($value) or ! $value instanceof Closure)) {
+                        @trigger_error(sprintf(
+                            'Providing option "%s" as type "callable" is deprecated since version 1.5, provide "%s" instead.',
+                            $key,
+                            Closure::class
+                        ), \E_USER_DEPRECATED);
+
+                        $value = function(string $url, string $content) use ($value): string {
+                            return call_user_func($value, $url, $content);
+                        };
+                    }
+
+                    if (! is_object($value) or ! $value instanceof Closure) {
+                        throw new InvalidArgumentException(sprintf(
+                            'Option "%s" must be of type "%s", "%s" given.',
+                            $key,
+                            Closure::class,
+                            function_exists('get_debug_type') ? get_debug_type($value): (is_object($value) ? get_class($value) : gettype($value))
+                        ));
                     }
 
                     $this->htmlLinkCreator = $value;
@@ -96,8 +113,25 @@ final class UrlLinker implements UrlLinkerInterface
                     break;
 
                 case 'emailLinkCreator':
-                    if (! is_callable($value)) {
-                        throw new InvalidArgumentException('The value of the emailLinkCreator option must be callable.');
+                    if (is_callable($value) and (! is_object($value) or ! $value instanceof Closure)) {
+                        @trigger_error(sprintf(
+                            'Providing option "%s" as type "callable" is deprecated since version 1.5, provide "%s" instead.',
+                            $key,
+                            Closure::class
+                        ), \E_USER_DEPRECATED);
+
+                        $value = function(string $url, string $content) use ($value): string {
+                            return call_user_func($value, $url, $content);
+                        };
+                    }
+
+                    if (! is_object($value) or ! $value instanceof Closure) {
+                        throw new InvalidArgumentException(sprintf(
+                            'Option "%s" must be of type "%s", "%s" given.',
+                            $key,
+                            Closure::class,
+                            function_exists('get_debug_type') ? get_debug_type($value): (is_object($value) ? get_class($value) : gettype($value))
+                        ));
                     }
 
                     $this->emailLinkCreator = $value;
@@ -114,14 +148,14 @@ final class UrlLinker implements UrlLinkerInterface
 
     /**
      * @deprecated since version 1.1, to be set to private in 2.0. Use config setting through __construct() instead
-     *
-     * @param bool $allowFtpAddresses
-     *
-     * @return self
      */
-    public function setAllowFtpAddresses($allowFtpAddresses)
+    public function setAllowFtpAddresses(bool $allowFtpAddresses): self
     {
-        @trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0. Use config setting through __construct() instead', E_USER_DEPRECATED);
+        @trigger_error(sprintf(
+            '"%s()" is deprecated since version 1.1 and will be removed in 2.0. Use config setting through "%s" instead.',
+            __METHOD__,
+            __CLASS__ . '::__construct()'
+        ), \E_USER_DEPRECATED);
 
         $this->allowFtpAddresses = (bool) $allowFtpAddresses;
 
@@ -130,26 +164,27 @@ final class UrlLinker implements UrlLinkerInterface
 
     /**
      * @deprecated since version 1.1, to be set to private in 2.0.
-     *
-     * @return bool
      */
-    public function getAllowFtpAddresses()
+    public function getAllowFtpAddresses(): bool
     {
-        @trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.', E_USER_DEPRECATED);
+        @trigger_error(sprintf(
+            '"%s()" is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.',
+            __METHOD__
+        ), \E_USER_DEPRECATED);
 
         return $this->allowFtpAddresses;
     }
 
     /**
      * @deprecated since version 1.1, to be set to private in 2.0. Use config setting through __construct() instead
-     *
-     * @param bool $allowUpperCaseUrlSchemes
-     *
-     * @return self
      */
-    public function setAllowUpperCaseUrlSchemes($allowUpperCaseUrlSchemes)
+    public function setAllowUpperCaseUrlSchemes(bool $allowUpperCaseUrlSchemes): self
     {
-        @trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0. Use config setting through __construct() instead', E_USER_DEPRECATED);
+        @trigger_error(sprintf(
+            '"%s()" is deprecated since version 1.1 and will be removed in 2.0. Use config setting through "%s" instead.',
+            __METHOD__,
+            __CLASS__ . '::__construct()'
+        ), \E_USER_DEPRECATED);
 
         $this->allowUpperCaseUrlSchemes = (bool) $allowUpperCaseUrlSchemes;
 
@@ -158,26 +193,27 @@ final class UrlLinker implements UrlLinkerInterface
 
     /**
      * @deprecated since version 1.1, to be set to private in 2.0.
-     *
-     * @return bool
      */
-    public function getAllowUpperCaseUrlSchemes()
+    public function getAllowUpperCaseUrlSchemes(): bool
     {
-        @trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.', E_USER_DEPRECATED);
+        @trigger_error(sprintf(
+            '"%s()" is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.',
+            __METHOD__
+        ), \E_USER_DEPRECATED);
 
         return $this->allowUpperCaseUrlSchemes;
     }
 
     /**
      * @deprecated since version 1.1, to be set to private in 2.0. Use config setting through __construct() instead
-     *
-     * @param Closure $creator
-     *
-     * @return self
      */
-    public function setHtmlLinkCreator(Closure $creator)
+    public function setHtmlLinkCreator(Closure $creator): self
     {
-        @trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0. Use config setting through __construct() instead', E_USER_DEPRECATED);
+        @trigger_error(sprintf(
+            '"%s()" is deprecated since version 1.1 and will be removed in 2.0. Use config setting through "%s" instead.',
+            __METHOD__,
+            __CLASS__ . '::__construct()'
+        ), \E_USER_DEPRECATED);
 
         $this->htmlLinkCreator = $creator;
 
@@ -186,26 +222,27 @@ final class UrlLinker implements UrlLinkerInterface
 
     /**
      * @deprecated since version 1.1, to be set to private in 2.0.
-     *
-     * @return Closure
      */
-    public function getHtmlLinkCreator()
+    public function getHtmlLinkCreator(): Closure
     {
-        @trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.', E_USER_DEPRECATED);
+        @trigger_error(sprintf(
+            '"%s()" is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.',
+            __METHOD__
+        ), \E_USER_DEPRECATED);
 
         return $this->htmlLinkCreator;
     }
 
     /**
      * @deprecated since version 1.1, to be set to private in 2.0. Use config setting through __construct() instead
-     *
-     * @param Closure $creator
-     *
-     * @return self
      */
-    public function setEmailLinkCreator(Closure $creator)
+    public function setEmailLinkCreator(Closure $creator): self
     {
-        @trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0. Use config setting through __construct() instead', E_USER_DEPRECATED);
+        @trigger_error(sprintf(
+            '"%s()" is deprecated since version 1.1 and will be removed in 2.0. Use config setting through "%s" instead.',
+            __METHOD__,
+            __CLASS__ . '::__construct()'
+        ), \E_USER_DEPRECATED);
 
         $this->emailLinkCreator = $creator;
 
@@ -214,12 +251,13 @@ final class UrlLinker implements UrlLinkerInterface
 
     /**
      * @deprecated since version 1.1, to be set to private in 2.0.
-     *
-     * @return Closure
      */
-    public function getEmailLinkCreator()
+    public function getEmailLinkCreator(): Closure
     {
-        @trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.', E_USER_DEPRECATED);
+        @trigger_error(sprintf(
+            '"%s()" is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.',
+            __METHOD__
+        ), \E_USER_DEPRECATED);
 
         return $this->emailLinkCreator;
     }
@@ -231,7 +269,11 @@ final class UrlLinker implements UrlLinkerInterface
      */
     public function setValidTlds(array $validTlds): self
     {
-        @trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0. Use config setting through __construct() instead', E_USER_DEPRECATED);
+        @trigger_error(sprintf(
+            '"%s()" is deprecated since version 1.1 and will be removed in 2.0. Use config setting through "%s" instead.',
+            __METHOD__,
+            __CLASS__ . '::__construct()'
+        ), \E_USER_DEPRECATED);
 
         $this->validTlds = $validTlds;
 
@@ -245,7 +287,10 @@ final class UrlLinker implements UrlLinkerInterface
      */
     public function getValidTlds(): array
     {
-        @trigger_error(__METHOD__ . ' is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.', E_USER_DEPRECATED);
+        @trigger_error(sprintf(
+            '"%s()" is deprecated since version 1.1 and will be removed in 2.0, don\'t use it anymore.',
+            __METHOD__
+        ), \E_USER_DEPRECATED);
 
         return $this->validTlds;
     }
@@ -284,7 +329,7 @@ final class UrlLinker implements UrlLinkerInterface
             $path        = $match[7][0];
 
             // Check that the TLD is valid or that $domain is an IP address.
-            $tld = strtolower(strrchr($domain, '.'));
+            $tld = strtolower((string) strrchr($domain, '.'));
 
             $validTlds = $this->validTlds;
 
@@ -460,6 +505,7 @@ final class UrlLinker implements UrlLinkerInterface
     {
         $flags = ENT_COMPAT | ENT_HTML401;
         $encoding = ini_get('default_charset');
+        $encoding = $encoding !== false ? $encoding : null;
         $double_encode = false; // Do not double encode
 
         return htmlspecialchars($string, $flags, $encoding, $double_encode);

--- a/src/UrlLinkerInterface.php
+++ b/src/UrlLinkerInterface.php
@@ -26,12 +26,12 @@ interface UrlLinkerInterface
      *
      * @return string
      */
-    public function linkUrlsAndEscapeHtml($text);
+    public function linkUrlsAndEscapeHtml(string $text)/* : string */;
 
     /**
      * @param string $html
      *
      * @return string
      */
-    public function linkUrlsInTrustedHtml($html);
+    public function linkUrlsInTrustedHtml(string $html)/* : string */;
 }

--- a/tests/Integration/UrlLinkerEscapingHtmlTest.php
+++ b/tests/Integration/UrlLinkerEscapingHtmlTest.php
@@ -40,7 +40,7 @@ class UrlLinkerEscapingHtmlTest extends UrlLinkerTestCase
      * @param mixed      $expectedLinked
      * @param null|mixed $message
      */
-    public function testFtpUrlsGetLinkedInText($text, $expectedLinked, $message = null)
+    public function testFtpUrlsGetLinkedInText(string $text, $expectedLinked, $message = null): void
     {
         $this->urlLinker = new UrlLinker([
             'allowFtpAddresses' => true,
@@ -56,7 +56,7 @@ class UrlLinkerEscapingHtmlTest extends UrlLinkerTestCase
      * @param mixed      $expectedLinked
      * @param null|mixed $message
      */
-    public function testUppercaseUrlsGetLinkedInText($text, $expectedLinked, $message = null)
+    public function testUppercaseUrlsGetLinkedInText(string $text, $expectedLinked, $message = null): void
     {
         $this->urlLinker = new UrlLinker([
             'allowUpperCaseUrlSchemes' => true,
@@ -70,12 +70,12 @@ class UrlLinkerEscapingHtmlTest extends UrlLinkerTestCase
      *
      * @param string $text
      */
-    public function testTextNotContainingAnyUrlsRemainsTheSame($text)
+    public function testTextNotContainingAnyUrlsRemainsTheSame(string $text): void
     {
         $this->assertSame($text, $this->urlLinker->linkUrlsAndEscapeHtml($text));
     }
 
-    public function testExample()
+    public function testExample(): void
     {
         $text = <<<EOD
 Here's an e-mail-address:bob+test@example.org. Here's an authenticated URL: http://skroob:12345@example.com.
@@ -129,7 +129,7 @@ EOD;
      * @param string      $expectedLinked
      * @param string|null $message
      */
-    public function testUrlsGetLinkedInText($text, $expectedLinked, $message = null)
+    public function testUrlsGetLinkedInText(string $text, string $expectedLinked, $message = null): void
     {
         $this->assertSame(
             $expectedLinked,
@@ -156,9 +156,8 @@ EOD;
      *
      * @param string      $text
      * @param string      $expectedLinked
-     * @param string|null $message
      */
-    public function testHtmlInText($text, $expectedLinked, $message = null)
+    public function testHtmlInText(string $text, string $expectedLinked): void
     {
         $this->urlLinker = new UrlLinker([
             'allowUpperCaseUrlSchemes' => true,
@@ -169,8 +168,10 @@ EOD;
 
     /**
      * provide html in text
+     *
+     * @return array<int,array<int,string>>
      */
-    public function provideTextsWithHtml()
+    public function provideTextsWithHtml(): array
     {
         return [
             [

--- a/tests/Integration/UrlLinkerEscapingHtmlTest.php
+++ b/tests/Integration/UrlLinkerEscapingHtmlTest.php
@@ -35,12 +35,8 @@ class UrlLinkerEscapingHtmlTest extends UrlLinkerTestCase
 
     /**
      * @dataProvider provideTextsWithFtpLinksWithoutHtml
-     *
-     * @param string     $text
-     * @param mixed      $expectedLinked
-     * @param null|mixed $message
      */
-    public function testFtpUrlsGetLinkedInText(string $text, $expectedLinked, $message = null): void
+    public function testFtpUrlsGetLinkedInText(string $text, string $expectedLinked, ?string $message = null): void
     {
         $this->urlLinker = new UrlLinker([
             'allowFtpAddresses' => true,
@@ -51,12 +47,8 @@ class UrlLinkerEscapingHtmlTest extends UrlLinkerTestCase
 
     /**
      * @dataProvider provideTextsWithUppercaseLinksWithoutHtml
-     *
-     * @param string     $text
-     * @param mixed      $expectedLinked
-     * @param null|mixed $message
      */
-    public function testUppercaseUrlsGetLinkedInText(string $text, $expectedLinked, $message = null): void
+    public function testUppercaseUrlsGetLinkedInText(string $text, string $expectedLinked, ?string $message = null): void
     {
         $this->urlLinker = new UrlLinker([
             'allowUpperCaseUrlSchemes' => true,

--- a/tests/Integration/UrlLinkerInTrustedHtmlTest.php
+++ b/tests/Integration/UrlLinkerInTrustedHtmlTest.php
@@ -40,7 +40,7 @@ class UrlLinkerInTrustedHtmlTest extends UrlLinkerTestCase
      * @param mixed      $expectedLinked
      * @param null|mixed $message
      */
-    public function testFtpUrlsGetLinkedInText($text, $expectedLinked, $message = null)
+    public function testFtpUrlsGetLinkedInText($text, $expectedLinked, $message = null): void
     {
         $this->urlLinker = new UrlLinker([
             'allowFtpAddresses' => true,
@@ -56,7 +56,7 @@ class UrlLinkerInTrustedHtmlTest extends UrlLinkerTestCase
      * @param mixed      $expectedLinked
      * @param null|mixed $message
      */
-    public function testUppercaseUrlsGetLinkedInText($text, $expectedLinked, $message = null)
+    public function testUppercaseUrlsGetLinkedInText($text, $expectedLinked, $message = null): void
     {
         $this->urlLinker = new UrlLinker([
             'allowUpperCaseUrlSchemes' => true,
@@ -70,12 +70,12 @@ class UrlLinkerInTrustedHtmlTest extends UrlLinkerTestCase
      *
      * @param string $text
      */
-    public function testTextNotContainingAnyUrlsRemainsTheSame($text)
+    public function testTextNotContainingAnyUrlsRemainsTheSame($text): void
     {
         $this->assertSame($text, $this->urlLinker->linkUrlsInTrustedHtml($text));
     }
 
-    public function testExample()
+    public function testExample(): void
     {
         $html = <<<EOD
 <p>Send me an <a href="bob@example.com">e-mail</a>
@@ -101,7 +101,7 @@ EOD;
      * @param string      $expectedLinked
      * @param string|null $message
      */
-    public function testUrlsGetLinkedInText($text, $expectedLinked, $message = null)
+    public function testUrlsGetLinkedInText($text, $expectedLinked, $message = null): void
     {
         $this->assertSame(
             $expectedLinked,
@@ -130,7 +130,7 @@ EOD;
      * @param string      $expectedLinked
      * @param string|null $message
      */
-    public function testHtmlInText($text, $expectedLinked, $message = null)
+    public function testHtmlInText($text, $expectedLinked, $message = null): void
     {
         $this->urlLinker = new UrlLinker([
             'allowUpperCaseUrlSchemes' => true,
@@ -141,8 +141,10 @@ EOD;
 
     /**
      * provide html in text
+     *
+     * @return array<int,array<int,string>>
      */
-    public function provideTextsWithHtml()
+    public function provideTextsWithHtml(): array
     {
         return [
             [

--- a/tests/Integration/UrlLinkerInTrustedHtmlTest.php
+++ b/tests/Integration/UrlLinkerInTrustedHtmlTest.php
@@ -35,12 +35,8 @@ class UrlLinkerInTrustedHtmlTest extends UrlLinkerTestCase
 
     /**
      * @dataProvider provideTextsWithFtpLinksWithoutHtml
-     *
-     * @param string     $text
-     * @param mixed      $expectedLinked
-     * @param null|mixed $message
      */
-    public function testFtpUrlsGetLinkedInText($text, $expectedLinked, $message = null): void
+    public function testFtpUrlsGetLinkedInText(string $text, string $expectedLinked, ?string $message = null): void
     {
         $this->urlLinker = new UrlLinker([
             'allowFtpAddresses' => true,
@@ -51,12 +47,8 @@ class UrlLinkerInTrustedHtmlTest extends UrlLinkerTestCase
 
     /**
      * @dataProvider provideTextsWithUppercaseLinksWithoutHtml
-     *
-     * @param string     $text
-     * @param mixed      $expectedLinked
-     * @param null|mixed $message
      */
-    public function testUppercaseUrlsGetLinkedInText($text, $expectedLinked, $message = null): void
+    public function testUppercaseUrlsGetLinkedInText(string $text, string $expectedLinked, ?string $message = null): void
     {
         $this->urlLinker = new UrlLinker([
             'allowUpperCaseUrlSchemes' => true,
@@ -125,12 +117,8 @@ EOD;
 
     /**
      * @dataProvider provideTextsWithHtml
-     *
-     * @param string      $text
-     * @param string      $expectedLinked
-     * @param string|null $message
      */
-    public function testHtmlInText($text, $expectedLinked, $message = null): void
+    public function testHtmlInText(string $text, string $expectedLinked): void
     {
         $this->urlLinker = new UrlLinker([
             'allowUpperCaseUrlSchemes' => true,

--- a/tests/Integration/UrlLinkerTest.php
+++ b/tests/Integration/UrlLinkerTest.php
@@ -26,7 +26,7 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
     /**
      * @deprecated since version 1.1, to be removed in 2.0.
      */
-    public function testGetValidTlds()
+    public function testGetValidTlds(): void
     {
         $urlLinker = new UrlLinker();
 
@@ -40,7 +40,7 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
     /**
      * Test the default HtmlLinkCreator
      */
-    public function testDefaultHtmlLinkCreator()
+    public function testDefaultHtmlLinkCreator(): void
     {
         $urlLinker = new UrlLinker();
 
@@ -53,7 +53,7 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
     /**
      * Test a custom HtmlLinkCreator
      */
-    public function testCustomHtmlLinkCreator()
+    public function testCustomHtmlLinkCreator(): void
     {
         // Simple htmlLinkCreator
         $creator = function ($url, $content) {
@@ -73,7 +73,7 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
     /**
      * Test the default EmailLinkCreator
      */
-    public function testDefaultEmailLinkCreator()
+    public function testDefaultEmailLinkCreator(): void
     {
         $urlLinker = new UrlLinker();
 
@@ -86,7 +86,7 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
     /**
      * Test a custom EmailLinkCreator
      */
-    public function testCustomEmailLinkCreator()
+    public function testCustomEmailLinkCreator(): void
     {
         // Simple EmailLinkCreator
         $creator = function ($email, $content) {
@@ -106,7 +106,7 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
     /**
      * Test disable EmailLinkCreator
      */
-    public function testDisableEmailLinkCreator()
+    public function testDisableEmailLinkCreator(): void
     {
         // This EmailLinkCreator returns simply the email
         $creator = function ($email, $content) {
@@ -131,14 +131,17 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
      * @param mixed $text
      * @param mixed $expected
      */
-    public function testEscapingHtml($text, $expected)
+    public function testEscapingHtml($text, $expected): void
     {
         $urlLinker = new UrlLinker();
 
         $this->assertSame($expected, $urlLinker->linkUrlsAndEscapeHtml($text));
     }
 
-    public function providerEscapingHtml()
+    /**
+     * @return array<int,array<int,string>>
+     */
+    public function providerEscapingHtml(): array
     {
         return [
             [

--- a/tests/Integration/UrlLinkerTest.php
+++ b/tests/Integration/UrlLinkerTest.php
@@ -127,11 +127,8 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
      * Test html escaping
      *
      * @dataProvider providerEscapingHtml
-     *
-     * @param mixed $text
-     * @param mixed $expected
      */
-    public function testEscapingHtml($text, $expected): void
+    public function testEscapingHtml(string $text, string $expected): void
     {
         $urlLinker = new UrlLinker();
 

--- a/tests/Integration/UrlLinkerTestCase.php
+++ b/tests/Integration/UrlLinkerTestCase.php
@@ -24,9 +24,9 @@ use PHPUnit\Framework\TestCase;
 abstract class UrlLinkerTestCase extends TestCase
 {
     /**
-     * @return array
+     * @return array<int,array<int,string>>
      */
-    public function provideTextsNotContainingAnyUrls()
+    public function provideTextsNotContainingAnyUrls(): array
     {
         return [
             [''],
@@ -37,9 +37,9 @@ abstract class UrlLinkerTestCase extends TestCase
     }
 
     /**
-     * @return array
+     * @return array<int,array<int,string>>
      */
-    public function provideTextsWithFtpLinksWithoutHtml()
+    public function provideTextsWithFtpLinksWithoutHtml(): array
     {
         return [
             // simple
@@ -51,9 +51,9 @@ abstract class UrlLinkerTestCase extends TestCase
     }
 
     /**
-     * @return array
+     * @return array<int,array<int,string>>
      */
-    public function provideTextsWithUppercaseLinksWithoutHtml()
+    public function provideTextsWithUppercaseLinksWithoutHtml(): array
     {
         return [
             // simple
@@ -65,9 +65,9 @@ abstract class UrlLinkerTestCase extends TestCase
     }
 
     /**
-     * @return array
+     * @return array<int,array<int,string>>
      */
-    public function provideTextsWithLinksWithoutHtml()
+    public function provideTextsWithLinksWithoutHtml(): array
     {
         return [
             // simple
@@ -181,12 +181,9 @@ abstract class UrlLinkerTestCase extends TestCase
     }
 
     /**
-     * @param string $href
-     * @param string $content
-     *
-     * @return string
+     * Create a HTML link from href and content
      */
-    protected function link($href, $content)
+    protected function link(string $href, string $content): string
     {
         return sprintf('<a href="%s">%s</a>', $href, $content);
     }

--- a/tests/Unit/DomainStorageTest.php
+++ b/tests/Unit/DomainStorageTest.php
@@ -24,7 +24,7 @@ use Youthweb\UrlLinker\DomainStorage;
 
 class DomainStorageTest extends TestCase
 {
-    public function testGetValidTlds()
+    public function testGetValidTlds(): void
     {
         $tlds = DomainStorage::getValidTlds();
 

--- a/tests/Unit/UrlLinkerTest.php
+++ b/tests/Unit/UrlLinkerTest.php
@@ -46,7 +46,7 @@ class UrlLinkerTest extends TestCase
     public function throwExceptionWithWrongHtmllinkcreator(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The value of the htmlLinkCreator option must be callable.');
+        $this->expectExceptionMessage('Option "htmlLinkCreator" must be of type "Closure", "string" given.');
 
         $config = [
             'htmlLinkCreator' => 'this must be a Closure',
@@ -61,7 +61,7 @@ class UrlLinkerTest extends TestCase
     public function throwExceptionWithWrongEmaillinkcreator(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The value of the emailLinkCreator option must be callable.');
+        $this->expectExceptionMessage('Option "emailLinkCreator" must be of type "Closure", "string" given.');
 
         $config = [
             'emailLinkCreator' => 'this must be a Closure',

--- a/tests/Unit/UrlLinkerTest.php
+++ b/tests/Unit/UrlLinkerTest.php
@@ -28,7 +28,7 @@ class UrlLinkerTest extends TestCase
     /**
      * @test UrlLinker implements UrlLinkerInterface
      */
-    public function testItImplementsUrlLinkerInterface()
+    public function testItImplementsUrlLinkerInterface(): void
     {
         $urlLinker = new UrlLinker();
 
@@ -43,7 +43,7 @@ class UrlLinkerTest extends TestCase
     /**
      * @test UrlLinker throws Exception with wrong htmlLinkCreator
      */
-    public function throwExceptionWithWrongHtmllinkcreator()
+    public function throwExceptionWithWrongHtmllinkcreator(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The value of the htmlLinkCreator option must be callable.');
@@ -58,7 +58,7 @@ class UrlLinkerTest extends TestCase
     /**
      * @test UrlLinker throws Exception with wrong emailLinkCreator
      */
-    public function throwExceptionWithWrongEmaillinkcreator()
+    public function throwExceptionWithWrongEmaillinkcreator(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The value of the emailLinkCreator option must be callable.');
@@ -73,7 +73,7 @@ class UrlLinkerTest extends TestCase
     /**
      * @test Closures are allowed as htmlLinkCreator
      */
-    public function allowClosureAsHtmllinkcreator()
+    public function allowClosureAsHtmllinkcreator(): void
     {
         $config = [
             'htmlLinkCreator' => function () {
@@ -93,7 +93,7 @@ class UrlLinkerTest extends TestCase
     /**
      * @test Closures are allowed as emailLinkCreator
      */
-    public function allowClosureAsEmaillinkcreator()
+    public function allowClosureAsEmaillinkcreator(): void
     {
         $config = [
             'emailLinkCreator' => function () {
@@ -113,7 +113,7 @@ class UrlLinkerTest extends TestCase
     /**
      * @test Callables are allowed as htmlLinkCreator
      */
-    public function allowCallableAsHtmllinkcreator()
+    public function allowCallableAsHtmllinkcreator(): void
     {
         $config = [
             'htmlLinkCreator' => [$this, '__construct'],
@@ -132,7 +132,7 @@ class UrlLinkerTest extends TestCase
     /**
      * @test Callables are allowed as emailLinkCreator
      */
-    public function allowCallableAsEmaillinkcreator()
+    public function allowCallableAsEmaillinkcreator(): void
     {
         $config = [
             'emailLinkCreator' => [$this, '__construct'],
@@ -151,7 +151,7 @@ class UrlLinkerTest extends TestCase
     /**
      * @deprecated since version 1.1, to be removed in 2.0.
      */
-    public function testAllowFtpAddressesConfig()
+    public function testAllowFtpAddressesConfig(): void
     {
         $urlLinker = new UrlLinker();
 
@@ -165,7 +165,7 @@ class UrlLinkerTest extends TestCase
     /**
      * @deprecated since version 1.1, to be removed in 2.0.
      */
-    public function testAllowUpperCaseUrlSchemesConfig()
+    public function testAllowUpperCaseUrlSchemesConfig(): void
     {
         $urlLinker = new UrlLinker();
 
@@ -179,7 +179,7 @@ class UrlLinkerTest extends TestCase
     /**
      * @deprecated since version 1.1, to be removed in 2.0.
      */
-    public function testValidTldsConfig()
+    public function testValidTldsConfig(): void
     {
         $urlLinker = new UrlLinker();
 
@@ -195,7 +195,7 @@ class UrlLinkerTest extends TestCase
      *
      * @deprecated since version 1.1, to be removed in 2.0.
      */
-    public function testGetHtmlLinkCreator()
+    public function testGetHtmlLinkCreator(): void
     {
         $urlLinker = new UrlLinker();
 
@@ -207,7 +207,7 @@ class UrlLinkerTest extends TestCase
      *
      * @deprecated since version 1.1, to be removed in 2.0.
      */
-    public function testSetHtmlLinkCreator()
+    public function testSetHtmlLinkCreator(): void
     {
         $urlLinker = new UrlLinker();
 
@@ -227,7 +227,7 @@ class UrlLinkerTest extends TestCase
      *
      * @deprecated since version 1.1, to be removed in 2.0.
      */
-    public function testGetEmailLinkCreator()
+    public function testGetEmailLinkCreator(): void
     {
         $urlLinker = new UrlLinker();
 
@@ -239,7 +239,7 @@ class UrlLinkerTest extends TestCase
      *
      * @deprecated since version 1.1, to be removed in 2.0.
      */
-    public function testSetEmailLinkCreator()
+    public function testSetEmailLinkCreator(): void
     {
         $urlLinker = new UrlLinker();
 
@@ -257,7 +257,7 @@ class UrlLinkerTest extends TestCase
     /**
      * @deprecated since version 1.1, to be removed in 2.0.
      */
-    public function testAllowingFtpAddresses()
+    public function testAllowingFtpAddresses(): void
     {
         $urlLinker = new UrlLinker();
         $urlLinker->setAllowFtpAddresses(true);
@@ -280,7 +280,7 @@ class UrlLinkerTest extends TestCase
     /**
      * @deprecated since version 1.1, to be removed in 2.0.
      */
-    public function testAllowingUpperCaseSchemes()
+    public function testAllowingUpperCaseSchemes(): void
     {
         $urlLinker = new UrlLinker();
         $urlLinker->setAllowUpperCaseUrlSchemes(true);


### PR DESCRIPTION
This PR add PHPStan to check the static code for errors.

This PR also adds declaration for all attributes, parameters and return values in every class. An exception is the `UrlLinkerInterface` where adding return type declaration would be a BC break. This will be add in version 2.0 instead.

In #5 there was added the possibility to provide the `htmlLinkCreator` and `emailLinkCreator` as `callable`. This was not intended and providing callables is now deprecated. A `Closure` should be provided instead.

```diff
$urlLinker = new Youthweb\UrlLinker\UrlLinker([
-  'emailLinkCreator' => 'some_function_name',
+  'emailLinkCreator' => function(string $email, string $content): string {
+    return some_function_name($email, $content);
+  },
]);
```