### PR TITLE
Run tests with PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2']
+        php: ['8.2', '8.3']
 
     name: "PHPStan on PHP ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.php == '8.2' }}
+    continue-on-error: ${{ matrix.php == '8.3' }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP with latest composer
         uses: shivammathur/setup-php@v2
@@ -33,12 +33,12 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: "Install Composer dependencies (PHP < 8.2)"
-        if: ${{ matrix.php < '8.2' }}
+      - name: "Install Composer dependencies (PHP < 8.3)"
+        if: ${{ matrix.php < '8.3' }}
         uses: "ramsey/composer-install@v2"
 
-      - name: "Install Composer dependencies (PHP 8.2)"
-        if: ${{ matrix.php >= '8.2' }}
+      - name: "Install Composer dependencies (PHP 8.3)"
+        if: ${{ matrix.php >= '8.3' }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs
@@ -52,14 +52,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
 
     name: "PHPUnit on PHP ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.php == '8.2' }}
+    continue-on-error: ${{ matrix.php == '8.3' }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP with latest composer
         uses: shivammathur/setup-php@v2
@@ -71,12 +71,12 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: "Install Composer dependencies (PHP < 8.2)"
-        if: ${{ matrix.php < '8.2' }}
+      - name: "Install Composer dependencies (PHP < 8.3)"
+        if: ${{ matrix.php < '8.3' }}
         uses: "ramsey/composer-install@v2"
 
-      - name: "Install Composer dependencies (PHP 8.2)"
-        if: ${{ matrix.php >= '8.2' }}
+      - name: "Install Composer dependencies (PHP 8.3)"
+        if: ${{ matrix.php >= '8.3' }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version](https://img.shields.io/github/release/youthweb/urllinker.svg)](https://github.com/youthweb/urllinker/releases)
 [![Software License](https://img.shields.io/badge/license-GPL3-brightgreen.svg)](LICENSE.md)
-[![Build Status](https://github.com/youthweb/urllinker/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/youthweb/urllinker/actions)
+[![Build Status](https://github.com/youthweb/urllinker/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/youthweb/urllinker/actions)
 [![Total Downloads](https://img.shields.io/packagist/dt/youthweb/urllinker.svg)](https://packagist.org/packages/youthweb/urllinker)
 
 UrlLinker converts any web addresses in plain text into HTML hyperlinks.


### PR DESCRIPTION
PHP 8.2 is released, so tests with PHP 8.2 are no longer allowed to fail.
This PR also run the tests with PHP 8.3 that is now in development.