### PR TITLE
Check return type of closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/youthweb/urllinker/compare/1.5.0...main)
+## [Unreleased](https://github.com/youthweb/urllinker/compare/1.5.0...stable1.5)
+
+### Deprecated
+
+- Providing a `htmlLinkCreator` Closure, that does not return a `string` is deprecated, let your `Closure` always return a `string` instead.
+- Providing a `emailLinkCreator` Closure, that does not return a `string` is deprecated, let your `Closure` always return a `string` instead.
 
 ## [1.5.0](https://github.com/youthweb/urllinker/compare/1.4.0...1.5.0) - 2022-12-07
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,7 @@
 		 backupGlobals="false"
 		 backupStaticAttributes="false"
 		 colors="true"
+		 convertDeprecationsToExceptions="true"
 		 convertErrorsToExceptions="true"
 		 convertWarningsToExceptions="true"
 		 convertNoticesToExceptions="true"

--- a/src/UrlLinker.php
+++ b/src/UrlLinker.php
@@ -431,10 +431,20 @@ final class UrlLinker implements UrlLinkerInterface
                     $completeUrl = $scheme ? $url : "http://$url";
                     $linkText = "$domain$port$path";
 
-                    $htmlLinkCreator = $this->htmlLinkCreator;
+                    $htmlLink = $this->htmlLinkCreator->__invoke($completeUrl, $linkText);
+
+                    if (! is_string($htmlLink)) {
+                        @trigger_error(sprintf(
+                            'Return value of Closure for "%s" returns type "%s" and will be casted to "string". This is deprecated since version 1.5.1 and will throw an "UnexpectedValueException" in version 2.0, return "string" instead.',
+                            'htmlLinkCreator',
+                            gettype($htmlLink)
+                        ), \E_USER_DEPRECATED);
+
+                        $htmlLink = (string) $htmlLink;
+                    }
 
                     // Add the hyperlink.
-                    $html .= $htmlLinkCreator($completeUrl, $linkText);
+                    $html .= $htmlLink;
                 }
             } else {
                 // Not a valid URL.

--- a/src/UrlLinker.php
+++ b/src/UrlLinker.php
@@ -127,19 +127,7 @@ final class UrlLinker implements UrlLinkerInterface
                             Closure::class
                         ), \E_USER_DEPRECATED);
 
-                        $value = function (string $url, string $content) use ($value): string {
-                            $return = call_user_func($value, $url, $content);
-
-                            if (! is_string($return)) {
-                                throw new UnexpectedValueException(sprintf(
-                                    'Return value of callable for "%s" must return value of type "string", "%s" given.',
-                                    'htmlLinkCreator',
-                                    function_exists('get_debug_type') ? get_debug_type($value) : (is_object($value) ? get_class($value) : gettype($value))
-                                ));
-                            }
-
-                            return $return;
-                        };
+                        $value = Closure::fromCallable($value);
                     }
 
                     if (! is_object($value) or ! $value instanceof Closure) {
@@ -171,19 +159,7 @@ final class UrlLinker implements UrlLinkerInterface
                             Closure::class
                         ), \E_USER_DEPRECATED);
 
-                        $value = function (string $url, string $content) use ($value): string {
-                            $return = call_user_func($value, $url, $content);
-
-                            if (! is_string($return)) {
-                                throw new UnexpectedValueException(sprintf(
-                                    'Return value of callable for "%s" must return value of type "string", "%s" given.',
-                                    'htmlLinkCreator',
-                                    function_exists('get_debug_type') ? get_debug_type($value) : (is_object($value) ? get_class($value) : gettype($value))
-                                ));
-                            }
-
-                            return $return;
-                        };
+                        $value = Closure::fromCallable($value);
                     }
 
                     if (! is_object($value) or ! $value instanceof Closure) {

--- a/src/UrlLinker.php
+++ b/src/UrlLinker.php
@@ -80,7 +80,7 @@ final class UrlLinker implements UrlLinkerInterface
 
                     if (! is_bool($value)) {
                         @trigger_error(sprintf(
-                            'Providing option "%s" not as type "boolean" is deprecated since version 1.5 and will not casted in version 2.0, provide as "boolean" instead.',
+                            'Providing option "%s" not as type "boolean" is deprecated since version 1.5.0 and will not be casted in version 2.0, provide as "boolean" instead.',
                             $key
                         ), \E_USER_DEPRECATED);
 
@@ -100,7 +100,7 @@ final class UrlLinker implements UrlLinkerInterface
 
                     if (! is_bool($value)) {
                         @trigger_error(sprintf(
-                            'Providing option "%s" not as type "boolean" is deprecated since version 1.5 and will not casted in version 2.0, provide as "boolean" instead.',
+                            'Providing option "%s" not as type "boolean" is deprecated since version 1.5.0 and will not be casted in version 2.0, provide as "boolean" instead.',
                             $key
                         ), \E_USER_DEPRECATED);
 
@@ -122,7 +122,7 @@ final class UrlLinker implements UrlLinkerInterface
 
                     if (is_callable($value) and (! is_object($value) or ! $value instanceof Closure)) {
                         @trigger_error(sprintf(
-                            'Providing option "%s" as type "callable" is deprecated since version 1.5, provide "%s" instead.',
+                            'Providing option "%s" as type "callable" is deprecated since version 1.5.0, provide "%s" instead.',
                             $key,
                             Closure::class
                         ), \E_USER_DEPRECATED);
@@ -166,7 +166,7 @@ final class UrlLinker implements UrlLinkerInterface
 
                     if (is_callable($value) and (! is_object($value) or ! $value instanceof Closure)) {
                         @trigger_error(sprintf(
-                            'Providing option "%s" as type "callable" is deprecated since version 1.5, provide "%s" instead.',
+                            'Providing option "%s" as type "callable" is deprecated since version 1.5.0, provide "%s" instead.',
                             $key,
                             Closure::class
                         ), \E_USER_DEPRECATED);
@@ -412,10 +412,20 @@ final class UrlLinker implements UrlLinkerInterface
 
                 if (! $scheme && $username && ! $password && ! $afterDomain) {
                     // Looks like an email address.
-                    $emailLinkCreator = $this->emailLinkCreator;
+                    $emailLink = $this->emailLinkCreator->__invoke($url, $url);
+
+                    if (! is_string($emailLink)) {
+                        @trigger_error(sprintf(
+                            'Return value of Closure for "%s" returns type "%s" and will be casted to "string". This is deprecated since version 1.5.1 and will throw an "UnexpectedValueException" in version 2.0, return "string" instead.',
+                            'emailLinkCreator',
+                            gettype($emailLink)
+                        ), \E_USER_DEPRECATED);
+
+                        $emailLink = (string) $emailLink;
+                    }
 
                     // Add the hyperlink.
-                    $html .= $emailLinkCreator($url, $url);
+                    $html .= $emailLink;
                 } else {
                     // Prepend http:// if no scheme is specified
                     $completeUrl = $scheme ? $url : "http://$url";

--- a/tests/Integration/UrlLinkerTest.php
+++ b/tests/Integration/UrlLinkerTest.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 
 namespace Youthweb\UrlLinker\Tests\Integration;
 
-use PHPUnit\Framework\Error\Deprecated;
 use Youthweb\UrlLinker\UrlLinker;
 
 class UrlLinkerTest extends \PHPUnit\Framework\TestCase
@@ -96,7 +95,6 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
         return '<a href="' . $url . '" target="_blank">' . $content . '</a>';
     }
 
-
     /**
      * Test the default EmailLinkCreator
      */
@@ -170,29 +168,6 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
      */
     public function customEmailLinkCreatorCallable(string $email, string $content): string {
         return '<a href="' . $email . '" class="email">' . $content . '</a>';
-    }
-
-    /**
-     * Test a custom EmailLinkCreator not returning a string will casted to string
-     */
-    public function testCustomEmailLinkCreatorNotReturningString(): void
-    {
-        $urlLinker = new UrlLinker([
-            'emailLinkCreator' => function($email, $content) { return 123; },
-        ]);
-
-        $this->expectDeprecation();
-        $this->expectDeprecationMessage('Return value of Closure for "emailLinkCreator" returns type "integer" and will be casted to "string". This is deprecated since version 1.5.1 and will throw an "UnexpectedValueException" in version 2.0, return "string" instead.');
-
-        $oldErrorHandler = set_error_handler(function ($errno, $errstr, $errline, $errfile) {
-            if ($errno & \E_USER_DEPRECATED) {
-                throw new Deprecated((string) $errstr, (int) $errno, (string) $errfile, (int) $errline);
-            }
-        });
-
-        $urlLinker->linkUrlsInTrustedHtml('Email: mail@example.com');
-
-        set_error_handler($oldErrorHandler);
     }
 
     /**

--- a/tests/Integration/UrlLinkerTest.php
+++ b/tests/Integration/UrlLinkerTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace Youthweb\UrlLinker\Tests\Integration;
 
+use PHPUnit\Framework\Error\Deprecated;
 use Youthweb\UrlLinker\UrlLinker;
 
 class UrlLinkerTest extends \PHPUnit\Framework\TestCase
@@ -169,6 +170,29 @@ class UrlLinkerTest extends \PHPUnit\Framework\TestCase
      */
     public function customEmailLinkCreatorCallable(string $email, string $content): string {
         return '<a href="' . $email . '" class="email">' . $content . '</a>';
+    }
+
+    /**
+     * Test a custom EmailLinkCreator not returning a string will casted to string
+     */
+    public function testCustomEmailLinkCreatorNotReturningString(): void
+    {
+        $urlLinker = new UrlLinker([
+            'emailLinkCreator' => function($email, $content) { return 123; },
+        ]);
+
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage('Return value of Closure for "emailLinkCreator" returns type "integer" and will be casted to "string". This is deprecated since version 1.5.1 and will throw an "UnexpectedValueException" in version 2.0, return "string" instead.');
+
+        $oldErrorHandler = set_error_handler(function ($errno, $errstr, $errline, $errfile) {
+            if ($errno & \E_USER_DEPRECATED) {
+                throw new Deprecated((string) $errstr, (int) $errno, (string) $errfile, (int) $errline);
+            }
+        });
+
+        $urlLinker->linkUrlsInTrustedHtml('Email: mail@example.com');
+
+        set_error_handler($oldErrorHandler);
     }
 
     /**


### PR DESCRIPTION
This PR will check the return type of the provided Closures. If the value is not a `string` a deprecation error is triggered and the value is cast to a `string` to keep BC. In v2 an `UnexpectedValueException` will be thrown instead.